### PR TITLE
New schema for lab machine data

### DIFF
--- a/bin/get
+++ b/bin/get
@@ -9,27 +9,37 @@ require '../lib/aggregator'
 # send : Array of Sessions -> void
 # Given an array of Sessions, throws every Session
 # that was within the last 10 minutes into CouchDb
-def send(sessions)
-  sessions.each do |session|
-    ten_minutes_ago = session.set - 10*60
-    if (session.ended and session.ended >= ten_minutes_ago) or (session.started and session.started >= ten_minutes_ago)
-      @couch.post('/'+@database, session.to_json)
-    end
+def send(data)
+  data.each do |entry|
+    @couch.post('/'+@database, entry.to_json)
   end
+  data
 end
 
-# get_last : String -> Array of Sessions
-# Given a filename for a Linux w10 file, grabs the file,
-# parses the contents, and throws the data into CouchDb
+# get_last : String Symbol Time -> Array of Sessions
 def get_last(filename, hostname, set)
   last = (`last -Ff #{filename}| grep -v root | grep -v system | head --lines=-2`).split("\n")
-  sessions = last.map do |line|
-    Aggregator::Parser.parse_last_line(line, hostname, set)
+
+  data = {
+    hostname: hostname,
+    os: :linux,
+    users: {
+      total: 0,
+      tty: 0,
+      pts: 0
+    },
+    timestamp: set
+  }
+
+  last.map do |line|
+    session = Aggregator::Parser.parse_last_line(line, hostname, set)
+    if session.should_send?
+      data[:users][session.source] += 1
+      data[:users][:total] += 1
+    end
   end
 
-  send sessions
-
-  sessions
+  send data
 end
 
 # get_windows : String -> Array of Sessions
@@ -40,8 +50,22 @@ def get_windows(filename)
   filename = "#{Aggregator::Config::WINDOWS_LOG_DIR}/#{filename}"
   file = IO.readlines(filename, 'r')[0]
   sessions = Aggregator::Parser.get_windows_log(file, set)
-  send sessions
-  sessions
+
+  data = {
+    hostname: hostname,
+    os: :windows,
+    users: {
+      total: 0
+    },
+    timestamp: set
+  }
+
+  last.map do |line|
+    session = Aggregator::Parser.parse_last_line(line, hostname, set)
+    data[:users][:total] += 1 if session.should_send?
+  end
+
+  send data
 end
 
 # Does everything

--- a/bin/get
+++ b/bin/get
@@ -2,26 +2,19 @@
 
 require '../lib/aggregator'
 
+@config = Aggregator::Config
+@database = @config::DATABASES[:lab_machines]
 @couch = Aggregator::CouchDB.new
 
 # send : Array of Sessions -> void
 # Given an array of Sessions, throws every Session
 # that was within the last 10 minutes into CouchDb
 def send(sessions)
-  database = Aggregator::Config::DATABASE
   sessions.each do |session|
     ten_minutes_ago = session.set - 10*60
-
     if (session.ended and session.ended >= ten_minutes_ago) or (session.started and session.started >= ten_minutes_ago)
-      puts "Sending #{session}"
-      @couch.post('/'+database, session.to_json)
-    else
-      puts ten_minutes_ago.asctime
-      puts session.started.asctime if session.started
-      puts session.ended.asctime if session.ended
-      puts "\n"
+      @couch.post('/'+@database, session.to_json)
     end
-
   end
 end
 
@@ -55,24 +48,26 @@ end
 def download_a_car
   puts "Downloading a car"
   # Linuxy things
-  linux_log_files = Dir.entries(Aggregator::Config::LINUX_LOG_DIR)
+  linux_log_files = Dir.entries(@config::LINUX_LOG_DIR)
   linux_log_files.delete('.')
   linux_log_files.delete('..')
   
+  puts "Linux files: #{linux_log_files.size}"
   linux_log_files.each do |filename|
     hostname, set = filename.split('-')
     hostname = hostname.intern
     set = Time.at(set.to_i)
-    filename = "#{Aggregator::Config::LINUX_LOG_DIR}/#{filename}"
+    filename = "#{@config::LINUX_LOG_DIR}/#{filename}"
     puts "file: #{filename},\thostname: #{hostname},\tset: #{set}"
     get_last(filename, hostname, set)
   end
 
   # Windowsy things
-  windows_log_files = Dir.entries(Aggregator::Config::WINDOWS_LOG_DIR)
+  windows_log_files = Dir.entries(@config::WINDOWS_LOG_DIR)
   windows_log_files.delete('.')
   windows_log_files.delete('..')
 
+  puts "Windows files: #{windows_log_files.size}"
   windows_log_files.each do |filename|
     puts "file: #{filename}"
     get_windows(filename)

--- a/config.rb.example
+++ b/config.rb.example
@@ -4,15 +4,21 @@ module Aggregator
     HOST = 'localhost'
     # CouchDB's port
     PORT = 1337
-    # The database
-    DATABASE = 'foobar'
+    # Databases
+    DATABASES = {
+      # Information about lab machines
+      lab_machines: 'lab_machines',
+      # Raw data from windows log files and wtmp files
+      raw_input: 'raw'
+    }
 
     # The directory the Windows log files are stored.
     # Windows log files have unix timestamps for names.
-    WINDOWS_LOG_DIR = '/where/your/windows/log/files/are/stored'
+    WINDOWS_LOG_DIR = '/tmp/windows'
+    # (These are custom created by one of our Systems guys.)
 
     # The directory the Linux w10 files are stored.
     # Linux log files have names like "#{hostname}-#{timestamp}".
-    LINUX_LOG_DIR = '/where/your/linux/log/files/are/stored'
+    LINUX_LOG_DIR = '/tmp/linux'
   end
 end

--- a/lib/aggregator/parser.rb
+++ b/lib/aggregator/parser.rb
@@ -20,7 +20,7 @@ module Aggregator
         line << nil
       elsif line[-3, 3].join(' ') == 'still logged in'
         line.pop(3)
-        line << nil
+        line << set
       else
         line.pop
         tmp = Time.from_asctime(line.pop(5).join(' '))

--- a/lib/aggregator/session.rb
+++ b/lib/aggregator/session.rb
@@ -30,6 +30,14 @@ module Aggregator
       hash.to_json
     end
 
+    # should_send? : Time -> Boolean
+    # Session should be counted/saved if it started or ended at least
+    # ten minutes after the given timestamp
+    def should_send?
+      ten_minutes_ago = @set - 10*60
+      (@ended and @ended >= ten_minutes_ago) or (@started and @started >= ten_minutes_ago)
+    end
+
   end
 end
 


### PR DESCRIPTION
Fixes #6 
Closes #4 
## New Schema
- hostname: the hostname of the machine
- os: "windows" or "linux"
- users: information about the number of users connected to the machine
  - total: the total number of users connected
  - tty: number of users physically at the machine (linux only)
  - pts: number of users ssh'd into the machine (linux only)
- timestamp: the timestamp for when this data was collected
### Examples

<table>
  <thead><tr><td>Windows machine</td><td>Linux machine</td></tr></thead>
  <tbody>
  <tr><td>
<pre>
{
   hostname: "beedrill",
   os: "windows",
   users: {
     total: 21
   },
   timestamp: 1359478515
}
</pre>
</td>
<td>
<pre>
{
   hostname: "majorhavoc",
   os: "linux",
   users: {
     total: 21,
     tty: 1,
     pts: 20
   },
   timestamp: 1359478515
}
</pre>
</td>
</tr>
</tbody>
</table>
